### PR TITLE
Fix session warning in PHP 7.1

### DIFF
--- a/SimpleQuiz/Utils/Session.php
+++ b/SimpleQuiz/Utils/Session.php
@@ -74,6 +74,7 @@ class Session implements Base\ISession {
         if ($sql) {
             return $sql->data;
         }
+        return '';
     }
 
     public function write($id,$data)


### PR DESCRIPTION
ElanMan/simple-quiz#31

This patch fixes the warning on line 22 of Session.php under PHP 7.1 (tested in 7.1.11 under Amazon Linux). 

Note that I have not experience the session_regenerate_id() issue in the referenced issue, so I don't know how/if that is resolved.